### PR TITLE
[WIP] CI Refactor

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,4 +1,5 @@
-name: Check pytest tests
+name: Check Pytest Tests
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -8,11 +9,72 @@ permissions:
   pull-requests: write
 
 jobs:
-  build:
+  find-changed-dirs:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+    outputs:
+      bounty_dirs_json: ${{ steps.collect-bounties.outputs.bounty_dirs_json }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # submodules: true # Fetch submodules as needed, not automatically
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Disable Git ownership check
+        run: git config --global --add safe.directory '*'
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remotes/origin/main
+
+      - name: Determine changed bounty directories
+        id: collect-bounties
+        run: |
+          # We skip changes that only affect exploit_report.txt, formatted_exploit_report.txt, README.md (non-essential). Can extend as needed.
+          SKIP_FILES_REGEX='(exploit_report\.txt|formatted_exploit_report\.txt|README\.md)$'
+
+          get_modified_dirs() {
+            git diff --diff-filter=ACMDR --name-only origin/main...HEAD | while read -r file; do
+              dir=$(dirname "$file")
+              if [[ "$dir" =~ .*/bounties/bounty_[0-9]*$ ]]; then
+                local changed_files
+                changed_files=$(git diff --diff-filter=ACMDR --name-only origin/main...HEAD -- "$dir")
+                non_skippable=$(echo "$changed_files" | grep -vE "$SKIPPABLE_FILES_REGEX" || true)
+                if [[ -n "$non_skippable" ]]; then
+                  echo "$dir"
+                fi
+              fi
+            done | sort -u
+          }
+
+          modified_dirs=$(get_modified_dirs)
+          echo "Modified (essential) directories: $modified_dirs"
+
+          if [[ -z "$modified_dirs" ]]; then
+            echo "No bounty directories found."
+            echo "bounty_dirs_json=[]" >> $GITHUB_OUTPUT
+          else
+            echo "Found modified bounty directories:"
+            echo "$modified_dirs"
+
+            # Remove any extra whitespace from the output and convert to JSON array
+            json_array=$(echo "$modified_dirs" | jq -R -s 'split("\n") | map(select(length > 0))')
+            
+            # Properly escape the JSON array for GITHUB_OUTPUT
+            escaped_json=$(echo "$json_array" | jq -c -r '@json')
+            echo "bounty_dirs_json=$escaped_json" >> $GITHUB_OUTPUT
+          fi
+
+  test-bounties:
+    needs: find-changed-dirs
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true # If we want to allow other bounties to run even if on fails, set to false. 
+      # Currently set to true to not waste CI compute.
+      matrix:
+        dir: ${{ fromJson(needs.find-changed-dirs.outputs.bounty_dirs_json) }}
+      max-parallel: 4 # Set to 4 to prevent overloading resources
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -23,7 +85,7 @@ jobs:
 
       - name: Disable Git ownership check
         run: git config --global --add safe.directory '*'
-        
+
       - name: Fetch main branch
         run: git fetch origin main:refs/remotes/origin/main
 
@@ -31,6 +93,14 @@ jobs:
         run: |
           sudo apt-get clean
           npm cache clean --force
+
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('.github/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Setup Python environment
         uses: actions/setup-python@v5
@@ -61,8 +131,7 @@ jobs:
       - name: Create Docker Network
         run: docker network create shared_net || true
 
-      - name: Find modified metadata/bounty directories
-        id: modified-dirs
+      - name: Setup shared functions
         run: |
           cat << 'EOF' > /tmp/shared_functions.sh
           execute_if_exists() {
@@ -75,41 +144,9 @@ jobs:
             fi
           }
 
-          get_modified_dirs() {
-            git diff --diff-filter=ACMDR --name-only origin/main...HEAD | awk -F/ '{print $1"/"$2"/"$3}' | sort -u | xargs -I{} find {} -type d -regex ".*/bounties/bounty_[0-9]*$" 2>/dev/null | sort -u
-          }
-
-          checkout_vulnerable_commit() {
-            local dir="$1"
-            if [[ -f "$dir/bounty_metadata.json" ]]; then
-              vulnerable_commit=$(jq -r '.["vulnerable_commit"]' "$dir/bounty_metadata.json")
-              
-              if [[ -n "$vulnerable_commit" ]]; then
-                echo "Found vulnerable commit: $vulnerable_commit in $dir"
-
-                git submodule update --init "$task_dir"
-                echo "Cleaning repository to remove all changes and untracked files..."
-                checkout_main "$dir"
-
-                task_dir=$(dirname "$(dirname "$dir")")
-                cd "$task_dir/codebase" || exit 1
-
-                # Update the submodule and checkout the vulnerable commit
-                git checkout "$vulnerable_commit"
-
-                cd - || exit 1
-              else
-                echo "No vulnerable commit found in $dir/bounty_metadata.json"
-                exit 1
-              fi
-            else
-              echo "No bounty_metadata.json file found in $dir"
-              exit 1
-            fi
-          }
-
           checkout_main() {
             local dir="$1"
+            local task_dir
             task_dir=$(dirname "$(dirname "$dir")")
             echo "Checking out main branch at $task_dir/codebase"
             cd "$task_dir/codebase" || exit 1
@@ -137,163 +174,185 @@ jobs:
             cd - || exit 1
           }
 
-          EOF
-          chmod +x /tmp/shared_functions.sh
-          source /tmp/shared_functions.sh
-          modified_dirs=$(get_modified_dirs)
-          if [ -z "$modified_dirs" ]; then
-            echo "No modified directories found. Exiting."
-            exit 1
-          else
-            echo "Modified directories: $modified_dirs"
-            echo "modified_dirs<<EOF" >> $GITHUB_OUTPUT
-            echo "$modified_dirs" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-          fi
+          checkout_vulnerable_commit() {
+            local dir="$1"
+            if [[ -f "$dir/bounty_metadata.json" ]]; then
+              local vulnerable_commit
+              vulnerable_commit=$(jq -r '.["vulnerable_commit"]' "$dir/bounty_metadata.json")
 
-      - name: Run Exploit Tests
-        if: steps.modified-dirs.outputs.modified_dirs != ''
-        run: |
-          source /tmp/shared_functions.sh
-          echo "${{ steps.modified-dirs.outputs.modified_dirs }}" | while read -r dir; do
-            task_dir=$(dirname "$(dirname "$dir")")
-            echo "Processing bug bounty: $dir"
+              if [[ -n "$vulnerable_commit" && "$vulnerable_commit" != "null" ]]; then
+                echo "Found vulnerable commit: $vulnerable_commit in $dir"
+                local task_dir
+                task_dir=$(dirname "$(dirname "$dir")")
 
-            checkout_vulnerable_commit "$dir"
+                echo "Initializing submodule in $task_dir"
+                git submodule update --init "$task_dir"
 
-            # Repo-level setup
-            echo "Setting up the repo environment for $dir"
-            cd "$task_dir"
-            execute_if_exists "setup_repo_env.sh"
-            cd -
+                echo "Cleaning repository before checkout"
+                checkout_main "$dir"
 
-            # Bounty-level setup
-            echo "Setting up the bounty environment for $dir"
-            cd "$dir/setup_files"
-            execute_if_exists "setup_bounty_env.sh"
-            cd -
-
-            # Run the exploit and verification for this task
-            echo "Running exploit and verification test for $dir"
-            pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_exploit.py::test_exploit_workflow --dirs "$dir"
-
-            # Stop Docker for this task
-            echo "Stopping Docker for $dir"
-            cd "$dir/setup_files"
-            execute_if_exists "stop_docker.sh"
-            cd -
-
-            # Stop Docker for this repo
-            echo "Stopping Docker for $task_dir"
-            cd "$task_dir"
-            execute_if_exists "stop_docker.sh"
-            cd -
-
-            checkout_main "$dir"
-
-            echo "Completed processing bug bounty: $dir"
-            echo "-----------------------------------"
-          done
-          echo "All tasks processed."
-
-      - name: Docker Cleanup before pulling new image
-        run: |
-          docker system prune -af
-          docker image prune -af
-
-      - name: Pull Docker Container
-        run: |
-          docker pull --quiet cybench/kali-linux-ci:latest
-          docker manifest inspect cybench/kali-linux-ci:latest
-          docker image tag cybench/kali-linux-ci:latest cybench
-      
-      - name: Create Docker Network
-        run: docker network create shared_net || true
-
-      - name: Run Patch Tests
-        if: steps.modified-dirs.outputs.modified_dirs != ''
-        run: |
-          source /tmp/shared_functions.sh
-          echo "${{ steps.modified-dirs.outputs.modified_dirs }}" | while read -r dir; do
-            task_dir=$(dirname "$(dirname "$dir")")
-            echo "Processing bug bounty: $dir"
-
-            checkout_vulnerable_commit "$dir"
-
-            # Patch the bug for this task
-            bounty_metadata="$dir/bounty_metadata.json"
-
-            patch_pairs=$(jq -r '.patch | to_entries[] | "\(.key) \(.value)"' "$bounty_metadata")
-
-            if [ -z "$patch_pairs" ]; then
-              echo "No patches defined for $dir. Skipping patch application."
-              checkout_main "$dir"
-              continue
+                cd "$task_dir/codebase" || exit 1
+                echo "Checking out vulnerable commit $vulnerable_commit"
+                git checkout "$vulnerable_commit"
+                cd - || exit 1
+              else
+                echo "No valid vulnerable_commit found in $dir/bounty_metadata.json"
+                exit 1
+              fi
             else
-              # Apply the patches by copying local files to their target locations
-              declare -A original_files
-              echo "Applying patches for $dir"
-              while read -r source_file target_file; do
-                # Ensure the target directory exists
-                target_dir=$(dirname "$target_file")
-                if [ ! -d "$task_dir/$target_dir" ]; then
-                  echo "Creating directory $task_dir/$target_dir"
-                  mkdir -p "$task_dir/$target_dir"
-                fi
+              echo "No bounty_metadata.json file found in $dir"
+              exit 1
+            fi
+          }
 
-                # Apply the patch by copying the source file to the target location
-                echo "Copying $dir/$source_file to $task_dir/$target_file"
-                cp "$dir/$source_file" "$task_dir/$target_file"
-              done <<< "$patch_pairs"
+          apply_patches_if_any() {
+            local dir="$1"
+            local bounty_metadata="$dir/bounty_metadata.json"
+            if [[ ! -f "$bounty_metadata" ]]; then
+              echo "No bounty_metadata.json found in $dir, skipping patch."
+              return
             fi
 
-             # Repo-level setup
-            echo "Setting up the repo environment for $dir"
+            local patch_pairs
+            patch_pairs=$(jq -r '.patch | to_entries[] | "\(.key) \(.value)"' "$bounty_metadata" 2>/dev/null || true)
+            if [[ -z "$patch_pairs" ]]; then
+              echo "No patches defined for $dir. Skipping patch application."
+              return
+            fi
+
+            local task_dir
+            task_dir=$(dirname "$(dirname "$dir")")
+
+            echo "Applying patches for $dir"
+            while read -r source_file target_file; do
+              if [[ -z "$source_file" || -z "$target_file" ]]; then
+                continue
+              fi
+              local target_dir
+              target_dir=$(dirname "$target_file")
+              if [ ! -d "$task_dir/$target_dir" ]; then
+                echo "Creating directory $task_dir/$target_dir"
+                mkdir -p "$task_dir/$target_dir"
+              fi
+              echo "Copying $dir/$source_file to $task_dir/$target_file"
+              cp "$dir/$source_file" "$task_dir/$target_file"
+            done <<< "$patch_pairs"
+          }
+          EOF
+          chmod +x /tmp/shared_functions.sh
+
+      - name: Run Exploit Tests
+        if: ${{ matrix.dir != '' }}
+        run: |
+          echo "Running exploit test for directory: ${{ matrix.dir }}"
+          source /tmp/shared_functions.sh
+
+          echo "Checking out vulnerable commit for ${{ matrix.dir }}"
+          checkout_vulnerable_commit "${{ matrix.dir }}"
+
+          echo "Running any repo-level setup if exists"
+          task_dir="$(dirname "$(dirname "${{ matrix.dir }}")")"
+          if [ -f "$task_dir/setup_repo_env.sh" ]; then
             cd "$task_dir"
             execute_if_exists "setup_repo_env.sh"
             cd -
+          fi
 
-            # Bounty-level setup
-            echo "Setting up the bounty environment for $dir"
-            cd "$dir/setup_files"
+          echo "Running any bounty-level setup if exists"
+          if [ -f "${{ matrix.dir }}/setup_files/setup_bounty_env.sh" ]; then
+            cd "${{ matrix.dir }}/setup_files"
             execute_if_exists "setup_bounty_env.sh"
             cd -
+          fi
 
-            # Run the patch test for this task
-            echo "Running patch test for $dir"
-            pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_patch.py::test_patch_workflow --dirs "$dir"
+          echo "Running exploit workflow via Pytest"
+          pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_exploit.py::test_exploit_workflow --dirs "${{ matrix.dir }}"
 
-            # Stop Docker for this task
-            echo "Stopping Docker for $dir"
-            cd "$dir/setup_files"
+          echo "Stopping Docker for this bounty"
+          if [ -f "${{ matrix.dir }}/setup_files/stop_docker.sh" ]; then
+            cd "${{ matrix.dir }}/setup_files"
             execute_if_exists "stop_docker.sh"
             cd -
+          fi
 
-            # Stop Docker for this repo
-            echo "Stopping Docker for $task_dir"
+          echo "Stopping Docker for this repo"
+          if [ -f "$task_dir/stop_docker.sh" ]; then
             cd "$task_dir"
             execute_if_exists "stop_docker.sh"
             cd -
-
-            checkout_main "$dir"
-
-            echo "Completed processing bug bounty: $dir"
-            echo "-----------------------------------"
-          done
-          echo "All tasks processed."
-
-
-      - name: Test bounty metadata.json
-        run: |
-          modified_files=$(git diff --diff-filter=ACM --name-only origin/main...HEAD | grep '.*/bounties/.*/bounty_metadata.json$' || true)
-          if [ -z "$modified_files" ]; then
-            echo "No relevant files in bounty metadata were modified."
-            exit 0  # Exit successfully if no files are modified
           fi
-          echo "Modified bounty_metadata.json files: $modified_files"
-          modified_dirs=$(echo "$modified_files" | tr "\n" "\0" | xargs -0 -n1 dirname | sort -u)
-          echo "$modified_dirs" | tr '\n' '\0' | xargs -0 pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_metadata_json.py::test_bounty_metadata --dirs
-          echo "Directories to be tested: $modified_dirs"
+
+          echo "Checking out main branch after exploit test"
+          checkout_main "${{ matrix.dir }}"
+
+      - name: Run Patch Tests
+        if: ${{ matrix.dir != '' }}
+        run: |
+          echo "Running patch test for directory: ${{ matrix.dir }}"
+          source /tmp/shared_functions.sh
+
+          echo "Checking out vulnerable commit for ${{ matrix.dir }}"
+          checkout_vulnerable_commit "${{ matrix.dir }}"
+
+          # Check if there are any patches to apply
+          bounty_metadata="${{ matrix.dir }}/bounty_metadata.json"
+          patch_pairs=$(jq -r '.patch | to_entries[] | "\(.key) \(.value)"' "$bounty_metadata" 2>/dev/null || echo "")
+
+          if [ -z "$patch_pairs" ]; then
+            echo "No patches defined for ${{ matrix.dir }}. Skipping patch test."
+            checkout_main "${{ matrix.dir }}"
+            exit 0
+          fi
+
+          echo "Applying patch if defined"
+          apply_patches_if_any "${{ matrix.dir }}"
+
+          task_dir="$(dirname "$(dirname "${{ matrix.dir }}")")"
+          
+          echo "Running any repo-level setup if exists"
+          task_dir="$(dirname "$(dirname "${{ matrix.dir }}")")"
+          if [ -f "$task_dir/setup_repo_env.sh" ]; then
+            cd "$task_dir"
+            execute_if_exists "setup_repo_env.sh"
+            cd -
+          fi
+
+          echo "Running any bounty-level setup if exists"
+          if [ -f "${{ matrix.dir }}/setup_files/setup_bounty_env.sh" ]; then
+            cd "${{ matrix.dir }}/setup_files"
+            execute_if_exists "setup_bounty_env.sh"
+            cd -
+          fi
+
+          echo "Running patch test via Pytest"
+          pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_patch.py::test_patch_workflow --dirs "${{ matrix.dir }}"
+
+          echo "Stopping Docker for this bounty"
+          if [ -f "${{ matrix.dir }}/setup_files/stop_docker.sh" ]; then
+            cd "${{ matrix.dir }}/setup_files"
+            execute_if_exists "stop_docker.sh"
+            cd -
+          fi
+
+          echo "Stopping Docker for this repo"
+          if [ -f "$task_dir/stop_docker.sh" ]; then
+            cd "$task_dir"
+            execute_if_exists "stop_docker.sh"
+            cd -
+          fi
+
+          echo "Checking out main branch after patch test"
+          checkout_main "${{ matrix.dir }}"
+
+      - name: Test bounty metadata
+        if: ${{ matrix.dir != '' }}
+        run: |
+          if [ -f "${{ matrix.dir }}/bounty_metadata.json" ]; then
+            echo "Testing bounty_metadata for ${{ matrix.dir }}"
+            pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_metadata_json.py::test_bounty_metadata --dirs "${{ matrix.dir }}"
+          else
+            echo "No bounty_metadata.json in ${{ matrix.dir }}. Skipping metadata test."
+          fi
 
       - name: Display disk space after tests
         run: df -h
@@ -301,6 +360,7 @@ jobs:
       - name: Docker Cleanup after tests
         run: |
           docker system prune -af
+          docker image prune -af
 
       - name: Display disk space after cleanup
         run: df -h

--- a/astropy/bounties/bounty_0/exploit_files/exploit.sh
+++ b/astropy/bounties/bounty_0/exploit_files/exploit.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
+cd ../../../codebase
+echo "Installing setuptools..."
+pip install setuptools==57.5.0 --force-reinstall
+pip install wheel
+echo "Installing extension_helpers, cython, numpy, and scipy..."
+pip install extension_helpers cython "numpy<1.25" scipy
+echo "Installing the current directory as an editable package..."
+pip install -e . --no-build-isolation --verbose
 
 python3 ../bounties/bounty_0/exploit_files/solve.py

--- a/gunicorn/bounties/bounty_0/setup_files/setup_bounty_env.sh
+++ b/gunicorn/bounties/bounty_0/setup_files/setup_bounty_env.sh
@@ -4,14 +4,4 @@
 # i.e. specific to this bounty. For instance, setting up a server
 # for a specific vulnerability.
 
-CURRENT_DIR=$(pwd)
-
-cd ../../../codebase
-
-git checkout 21.2.0
-
-pip install -e .
-
-cd "$CURRENT_DIR"
-
 ./start_docker.sh

--- a/tests/test_exploit.py
+++ b/tests/test_exploit.py
@@ -1,29 +1,39 @@
+# tests/test_exploit.py
 import pytest
-
 from tests.docker_helper import DockerHelper
 from tests.logger import logger, ERROR
 from tests.util import run_exploit_script, run_verify_script
 
+def pytest_addoption(parser):
+    """
+    This hook adds a custom --dirs command-line option to pytest,
+    enabling us to pass in multiple directories if desired.
+    """
+    parser.addoption(
+        "--dirs",
+        action="append",
+        default=[],
+        help="List of bounty directories to test."
+    )
 
-@pytest.fixture(scope="session")
-def dirs(request):
-    return request.config.getoption("--dirs")
-
+def pytest_generate_tests(metafunc):
+    """
+    Dynamically parametrize 'dir_path' based on --dirs input.
+    If user passes: pytest --dirs bounties/bounty_123 --dirs bounties/bounty_456
+    Then we get 2 tests: test_exploit_workflow[bounties/bounty_123], test_exploit_workflow[bounties/bounty_456]
+    """
+    if "dir_path" in metafunc.fixturenames:
+        dirs = []
+        for d in metafunc.config.getoption("dirs"):
+            # If someone passes space-separated or a single string, handle that:
+            dirs.extend(d.strip().split())
+        if dirs:
+            metafunc.parametrize("dir_path", dirs, ids=dirs)
 
 @pytest.fixture(scope="session")
 def docker_helper():
+    # We can keep it session-scoped if the DockerHelper is okay being reused across tests
     return DockerHelper()
-
-
-def test_exploit_workflow(dirs, docker_helper):
-    """Test exploits within given directories."""
-    if not dirs:
-        logger.info("No directories provided. Skipping tests.")
-        return
-
-    for dir_path in dirs:
-        exploit_workflow(dir_path, docker_helper)
-
 
 def exploit_workflow(path, docker_helper):
     logger.info(f"Running exploit workflow for {path}")
@@ -34,9 +44,10 @@ def exploit_workflow(path, docker_helper):
     if verify_result != 1:
         logger.error(ERROR)
         logger.error(
-            f"Verify script succeeded for {path} before exploit execution.\nVerify should return with exit code 1 but returned {verify_result}.")
-        pytest.fail(
-            f"Verify script succeeded for {path} before exploit execution.")
+            f"Verify script succeeded for {path} before exploit execution.\n"
+            f"Verify should return with exit code 1 but returned {verify_result}."
+        )
+        pytest.fail(f"Verify script succeeded for {path} before exploit execution.")
     else:
         logger.info(f"Verify fails with exit code {verify_result} as expected.")
 
@@ -49,8 +60,17 @@ def exploit_workflow(path, docker_helper):
     if verify_result != 0:
         logger.error(ERROR)
         logger.error(
-            f"Verify script failed for {path} after exploit execution.\nVerify should return with exit code 0 but returned {verify_result}.")
-        pytest.fail(
-            f"Verify script failed for {path} after exploit execution.")
+            f"Verify script failed for {path} after exploit execution.\n"
+            f"Verify should return with exit code 0 but returned {verify_result}."
+        )
+        pytest.fail(f"Verify script failed for {path} after exploit execution.")
     else:
         logger.info(f"Verify suceeds with exit code {verify_result} as expected.")
+
+
+@pytest.mark.usefixtures("docker_helper")
+def test_exploit_workflow(dir_path, docker_helper):
+    """
+    Each 'dir_path' is tested as a separate test case by Pytest.
+    """
+    exploit_workflow(dir_path, docker_helper)

--- a/tests/test_metadata_json.py
+++ b/tests/test_metadata_json.py
@@ -1,108 +1,55 @@
+# tests/test_metadata_json.py
 import json
 import logging
 import os
 import re
-import unittest
-
 import pytest
 from jsonschema import ValidationError, validate
 
 logger = logging.getLogger(__name__)
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dirs",
+        action="append",
+        default=[],
+        help="List of directories to test metadata for."
+    )
 
-@pytest.fixture(scope="session")
-def dirs(request):
-    return request.config.getoption("--dirs")
+def pytest_generate_tests(metafunc):
+    if "dir_path" in metafunc.fixturenames:
+        dirs = []
+        for d in metafunc.config.getoption("dirs"):
+            dirs.extend(d.strip().split())
+        if dirs:
+            metafunc.parametrize("dir_path", dirs, ids=dirs)
 
-
-def test_project_metadata(dirs: list[str]):
-    if not dirs:
-        logger.info("No modified project metadata detected. Skipping test")
+def test_bounty_metadata(dir_path):
+    """
+    Test the bounty_metadata.json file in dir_path, if present.
+    """
+    metadata_file = os.path.join(dir_path, 'bounty_metadata.json')
+    if not os.path.isfile(metadata_file):
+        logger.info(f"No bounty_metadata.json found in {dir_path}, skipping.")
         return
 
-    def test_metadata_files_exist(dirs: list[str]):
-        metadata_files: list[str] = []
-        for dir in dirs:
-            metadata_file = os.path.join(dir, 'metadata.json')
-            if os.path.isfile(metadata_file):
-                metadata_files.append(metadata_file)
-        assert len(
-            metadata_files) > 0, f"No metadata.json file found in directory: {dir}"
-
-    def test_metadata_structure(metadata_file, schema):
-        with open(metadata_file, 'r') as file:
-            data = json.load(file)
-        try:
-            validate(instance=data, schema=schema)
-            print("Validation successful")
-        except ValidationError as ve:
-            print("Validation error:", ve)
-            assert False, "JSON does not match schema"
-
-    dirs = [dir.strip() for dir in dirs]
-    test_metadata_files_exist(dirs)
-    schema_path = "project_metadata_schema.json"
-    schema = {}
-    with open(schema_path, 'r') as schema_file:
-        schema = json.load(schema_file)
-    metadata_files: list[str] = []
-    for dir in dirs:
-        metadata_file = os.path.join(dir, 'metadata.json')
-        if os.path.isfile(metadata_file):
-            metadata_files.append(metadata_file)
-    for file in metadata_files:
-        test_metadata_structure(file, schema)
-
-
-def test_bounty_metadata(dirs: list[str]):
-    if not dirs:
-        logger.info("No modified bounty metadata detected. Skipping test")
-        return
-
-    def test_metadata_files_exist(dirs: list[str]):
-        metadata_files: list[str] = []
-        for dir in dirs:
-            metadata_file = os.path.join(dir, 'bounty_metadata.json')
-            if os.path.isfile(metadata_file):
-                metadata_files.append(metadata_file)
-        assert len(
-            metadata_files) > 0, f"No bounty_metadata.json file found in directory: {dir}"
-
-    def test_metadata_structure(metadata_file, schema):
-        with open(metadata_file, 'r') as file:
-            data = json.load(file)
-        try:
-            validate(instance=data, schema=schema)
-            print("Validation successful")
-        except ValidationError as ve:
-            print("Validation error:", ve)
-            assert False, "JSON does not match schema"
-
-    def test_metadata_answer_format(metadata_file):
-        with open(metadata_file, 'r') as file:
-            data = json.load(file)
-
-        answer = data.get('answer', '')
-        answer_format = data.get('answer_format', '')
-
-        # Convert answer_format to a regex pattern
-        # Replace '*' with '.' to match any character
-        pattern = '^' + re.escape(answer_format).replace('\\*', '.') + '$'
-
-        assert re.match(
-            pattern, answer), f"Answer '{answer}' does not match the format '{answer_format}'"
-
-    dirs = [dir.strip() for dir in dirs]
-    test_metadata_files_exist(dirs)
+    # 1) Validate structure
     schema_path = "bounty_metadata_schema.json"
-    schema = {}
     with open(schema_path, 'r') as schema_file:
         schema = json.load(schema_file)
-    metadata_files: list[str] = []
-    for dir in dirs:
-        metadata_file = os.path.join(dir, 'bounty_metadata.json')
-        if os.path.isfile(metadata_file):
-            metadata_files.append(metadata_file)
-    for file in metadata_files:
-        test_metadata_structure(file, schema)
-        test_metadata_answer_format(file)
+
+    with open(metadata_file, 'r') as file:
+        data = json.load(file)
+    try:
+        validate(instance=data, schema=schema)
+        logger.info("Validation successful for: " + metadata_file)
+    except ValidationError as ve:
+        pytest.fail(f"Validation error in {metadata_file}: {ve}")
+
+    # 2) Validate answer format
+    answer = data.get('answer', '')
+    answer_format = data.get('answer_format', '')
+    pattern = '^' + re.escape(answer_format).replace('\\*', '.') + '$'
+    assert re.match(pattern, answer), (
+        f"Answer '{answer}' does not match format '{answer_format}'"
+    )

--- a/tests/test_patch.py
+++ b/tests/test_patch.py
@@ -1,50 +1,63 @@
+# tests/test_patch.py
 import pytest
-
 from tests.docker_helper import DockerHelper
 from tests.logger import logger
 from tests.util import run_exploit_script, run_verify_script
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--dirs",
+        action="append",
+        default=[],
+        help="List of bounty directories to test (patch)."
+    )
 
-@pytest.fixture(scope="session")
-def dirs(request):
-    return request.config.getoption("--dirs")
-
+def pytest_generate_tests(metafunc):
+    if "dir_path" in metafunc.fixturenames:
+        dirs = []
+        for d in metafunc.config.getoption("dirs"):
+            dirs.extend(d.strip().split())
+        if dirs:
+            metafunc.parametrize("dir_path", dirs, ids=dirs)
 
 @pytest.fixture(scope="session")
 def docker_helper():
     return DockerHelper()
 
-
-def test_patch_workflow(dirs, docker_helper):
-    """Test exploits within given directories."""
-    if not dirs:
-        logger.info("No directories provided. Skipping tests.")
-        return
-
-    for i, dir_path in enumerate(dirs):
-        patch_workflow(dir_path, docker_helper)
-
-
 def patch_workflow(path, docker_helper):
     logger.info(f"Running patch workflow for {path}")
 
-    logger.info(
-        f"Running verify script for {path} before executing the exploit")
+    logger.info(f"Running verify script for {path} before executing the exploit. Verify should fail.")
     verify_result = run_verify_script(path)
     if verify_result != 1:
         logger.error(
-            f"Verify script failed for {path} before exploit execution.\n Verify should return with exit code 1 but returned {verify_result}.")
+            f"Verify script failed for {path} before exploit execution.\n"
+            f"Verify should return with exit code 1 but returned {verify_result}."
+        )
         pytest.fail(
-            f"Verify script succeeded for {path} before exploit execution.")
+            f"Verify script succeeded for {path} before exploit execution."
+        )
+    else:
+        logger.info(f"Verify failed with exit code {verify_result} as expected.")
 
     logger.info(f"Running exploit for {path}")
     run_exploit_script(path, docker_helper)
 
     logger.info(
-        f"Running verify script for {path} after executing the exploit")
+        f"Running verify script for {path} after executing the exploit. Verify should fail.")
     verify_result = run_verify_script(path)
     if verify_result != 1:
         logger.error(
-            f"Verify script succeeded for {path} after exploit execution.\n Verify should return with exit code 1 but returned {verify_result}.")
+            f"Verify script succeeded for {path} after exploit execution.\n"
+            f"Verify should return with exit code 1 but returned {verify_result}."
+        )
         pytest.fail(
-            f"Verify script succeeded for {path} after exploit execution in the patch workflow.")
+            f"Verify script succeeded for {path} after exploit execution in patch workflow."
+        )
+    else:
+        logger.info(f"Verify failed with exit code {verify_result} as expected.")
+
+
+@pytest.mark.usefixtures("docker_helper")
+def test_patch_workflow(dir_path, docker_helper):
+    patch_workflow(dir_path, docker_helper)


### PR DESCRIPTION
Along with CI update to allow parallel ci tests (by bounty)
- edited astropy to pass CI
- edited gunicorn to pass CI

Todo:
May need to return better log of exploit if verification fails

Considerations: currently, isolated bounty runs all pull separate docker images. Can make a hybrid approach where there's one initial pull, all tests reference?

Ran against all bounties, lunary (0,1,2) failing (1 on exploit, 0,2 on patch) pytorch (0,1) both failing on patch exit 17?. 
Rest (7 bounties) succeeding