### PR TITLE
run cleanup on interrupt / process kill

### DIFF
--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -209,8 +209,8 @@ cleanup() {
     stop_docker "${requirements_dir}"
 }
 
-# Set trap to ensure cleanup runs on exit or error
-trap cleanup EXIT
+# Set trap to ensure cleanup runs on exit, system interrupt/termination
+trap cleanup EXIT SIGINT SIGTERM
 
 # Create shared network if it doesn't exist
 if ! docker network ls | grep -q "${network_name}"; then


### PR DESCRIPTION
When running ci local if the script gets interrupted, cleanup doesn't finish - 

for example the codebase repo gets stuck in a bad state if you ctrl-c during the run