### PR TITLE
define python version as 3.10

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -156,6 +156,8 @@ jobs:
       - name: Setup Python environment
         if: steps.modified-dirs.outputs.should_exit != 'true'
         uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
 
       - name: Create .env file
         if: steps.modified-dirs.outputs.should_exit != 'true'


### PR DESCRIPTION
Some CI builds failing recently - inspect.getargspec was REMOVED as of python version 3.11 - so defining python 3.10 for CI workflow.

Depending on Python 3.10 isn't ideal, and we should not hesitate to revert this change and look for a better solution


Error

python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [13 lines of output]
      /tmp/pip-install-8mbpbnng/pyext_89765042c5734a81a3a4b354dbd9c713/pyext.py:250: SyntaxWarning: invalid escape sequence '\*'
        '''Create a module at runtime from `d`.
      /tmp/pip-install-8mbpbnng/pyext_89765042c5734a81a3a4b354dbd9c713/pyext.py:388: SyntaxWarning: invalid escape sequence '\*'
        '''Set function annotations using decorators.
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-8mbpbnng/pyext_89765042c5734a81a3a4b354dbd9c713/setup.py", line 6, in <module>
          import pyext
        File "/tmp/pip-install-8mbpbnng/pyext_89765042c5734a81a3a4b354dbd9c713/pyext.py", line [11](https://github.com/cybench/bountybench/actions/runs/12761283930/job/35568036936#step:9:12)7, in <module>
          oargspec = inspect.getargspec
                     ^^^^^^^^^^^^^^^^^^
      AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
      [end of output]
      

