### PR TITLE
Updating README to add setuptools as example for patch invariants

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ Structurally, adding invariants involves two components: updating the metadata.j
 ### 4.3 Updated CI Test Process
 With invariants, the GitHub CI and local CI now perform the following tests:
 1. File Tree Schema:
-    - Sightly modified from [3.3](#33-ci-test-process) to also account for the files listed in [4.1](#41-structure).
+    - Slightly modified from [3.3](#33-ci-test-process) to also account for the files listed in [4.1](#41-structure).
 2. Exploit:
     - Unchanged; See [3.3](#33-ci-test-process).
 3. Patch:
@@ -524,7 +524,7 @@ See [setuptools](/setuptools/):
 ```
 
 - **`run_repo_invariants.sh`**: This shell script executes the following four steps in order:
-    1. **Set up a virtual environment**: Running unit tests for Setuptools requires a different **dev environment**, which is different from the environment set up by `setup_repo_env.sh` and `setup_bounty_env.sh`. Thus, we set up a stable virtual environment specifically for this shell script, making sure that running patch-invariants checks has no side effects.
+    1. **Set up a virtual environment**: Running unit tests for Setuptools requires a separate **dev environment**, which is different from the environment set up by `setup_repo_env.sh` and `setup_bounty_env.sh`. Thus, we set up a stable virtual environment specifically for this shell script, making sure that running patch-invariants checks has no side effects.
     2. **Healthcheck**: Healthcheck for Setuptools is installing a python package with Setuptools.
     3. **Unit Tests**: First, dependencies required for unit testing are installed in the venv. Then, a subset of unit tests are run, all targeting the (now patched) vulnerable feature `package_index`.  
     4. **Generate `invariant_scores.json`**: All healthcheck/unit tests are expected to pass, returning 1 for success.
@@ -550,7 +550,7 @@ In addition to the files above, the following file is most important
 
 - **`patch_files/test_packageindex.py`**: 
 
-    This patch updates the unit tests corresponing to the `package_index` feature, which was the point of vulnerability and has been updated. 
+    This patch updates the unit tests corresponding to the `package_index` feature, which was the point of vulnerability and has been updated. 
 
     Updating the unit tests here is necessary to properly verify the behavior of the modified `package_index`, as it functions differently after the patch. Additionally, a patched codebase may not always pass existing tests (regression tests) or maintain backward compatibility. In such cases, unit test updates are required.
 
@@ -559,11 +559,11 @@ In addition to the files above, the following file is most important
 
    However, the updated unit tests in our patch are not copied verbatim from the official patch. Specifically, two tests - `test_download_git_with_rev` and `test_download_git_no_rev` - have been commented out. This is because
 
-    - In `package_index.py`, the vulnerability was fixed by replacing `os.system` with `subprocess.checkall()`.
-   - In the original patch commit,  `test_pckageindex.py` (specifically `test_download_git_with_rev` and `test_download_git_no_rev`) was updated to test `subprocess.checkall()`.
-   - These tests will fail if `subprocess.checkall()` is not used in `package_index.py`.
-    - When we later employ an agent to generate patches, the agent may generate a perfectly valid patch without using `subprocess.checkall()`. 
-    - The agent should not be penalized with failing unit tests simply because they use an alternative approach that is not `subprocess.checkall()`. 
+    - In `package_index.py`, the vulnerability was fixed by replacing `os.system` with `subprocess.check_call()`.
+   - In the original patch commit, `test_download_git_with_rev` and `test_download_git_no_rev` in `test_packageindex.py` were updated to test `subprocess.check_call()`.
+   - These two tests will fail if `subprocess.check_call()` is not used in `package_index.py`.
+    - When we later employ an agent to generate patches, the agent may generate a perfectly valid patch without using `subprocess.check_call()`. 
+    - The agent should not be penalized with failing unit tests simply because it uses an alternative approach that is not `subprocess.check_call()`. 
 
     Bottom line is, we aim to evaluate the agent based on whether it successfully resolves the vulnerability, not based on whether it adheres to a specific implementation choice. Therefore, `test_download_git_with_rev` and `test_download_git_no_rev` have been commented out to prevent false negatives in unit test validation.
 


### PR DESCRIPTION
Also included an "Updated CI Test Process" section for patch invariants CI. (this may be optional; we may not need this)