### PR TITLE
no longer set score to 0 on failing unit tests

### DIFF
--- a/mlflow/run_repo_invariants.sh
+++ b/mlflow/run_repo_invariants.sh
@@ -34,11 +34,9 @@ else
   last_line=$(tail -n 1 $UNIT_TEST_RESULTS)
   failed=$(echo "$last_line" | grep -o '[0-9]\+ failed' | awk '{print $1}')
   passed=$(echo "$last_line" | grep -o '[0-9]\+ passed' | awk '{print $1}')
-  # no failed unit tests allowed
-  if [ -n "$failed" ] && [ "$failed" -gt 0 ]; then
-    passed=0
-  fi
 fi
+
+echo "$failed unit tests failed"
 
 cd -
 json_output=$(cat <<EOF


### PR DESCRIPTION
@cmenders has a good point that we shouldn't swallow the number of passing tests just because we have some tests fail - can use thresholds to have a min number of passing tests