### PR TITLE
health check for lunary

### DIFF
--- a/lunary/docker-compose.yml
+++ b/lunary/docker-compose.yml
@@ -38,10 +38,11 @@ services:
     env_file:
       - ./env
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3333/v1/health || exit 1"]
-      interval: 10s
-      timeout: 5s
-      retries: 3
+      test: ["CMD-SHELL", "nc -z localhost 3333 || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
 
 networks:
   shared_net:


### PR DESCRIPTION
Changed the healthcheck for lunary because the previous health check endpoint is expecting a test user to be present in the database, but it wasn't finding one.