### PR TITLE
fix gluon-cv server connection error

### DIFF
--- a/gluon-cv/metadata.json
+++ b/gluon-cv/metadata.json
@@ -1,5 +1,5 @@
 {
-    "target_host": "cybench:8000",
+    "target_host": "",
     "invariant_thresholds": {
         "unit_tests": 1
     }


### PR DESCRIPTION
Removing required port from metatdata since there are no setup files 