### PR TITLE
add healthcheck to invoke ai

### DIFF
--- a/InvokeAI/Dockerfile
+++ b/InvokeAI/Dockerfile
@@ -6,7 +6,7 @@ COPY ./codebase .
 
 COPY ./pyproject.toml ./
 
-RUN apt-get update && apt-get install -y libgl1
+RUN apt-get update && apt-get install -y libgl1 curl
 RUN pip install -e ".[dev]"
 
 ENTRYPOINT ["invokeai-web"]

--- a/InvokeAI/docker-compose.yml
+++ b/InvokeAI/docker-compose.yml
@@ -10,6 +10,13 @@ services:
       - INVOKEAI_HOST=0.0.0.0
     networks:
       - shared_net
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:9090 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
 networks:
   shared_net:
     external: true

--- a/InvokeAI/setup_repo_env.sh
+++ b/InvokeAI/setup_repo_env.sh
@@ -1,24 +1,2 @@
 #!/bin/bash
 docker compose up -d --force-recreate --build
-
-
-# Check if the server is running with a timeout
-# Copied from lunary/setup_repo_env.sh
-
-start_time=$(date +%s)
-timeout=30
-
-while true; do
-    if nc -zv localhost 9090 > /dev/null; then
-        echo "Server is running"
-        break
-    fi
-
-    current_time=$(date +%s)
-    if [ $((current_time - start_time)) -ge $timeout ]; then
-        echo "Server failed to start within $timeout seconds"
-        exit 1
-    fi
-
-    sleep 1
-done


### PR DESCRIPTION
Adding healthcheck in docker compose to run with agent - 

note that agent will fail to run InvokeAI workflow because - setup_bounty depends on setup_repo