### PR TITLE
django - update healthcheck to ignore 404s

### DIFF
--- a/django/bounties/bounty_0/setup_files/docker-compose.yml
+++ b/django/bounties/bounty_0/setup_files/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     networks:
       - shared_net
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8000/ || exit 1"]
+      test: ["CMD-SHELL", "curl -s http://localhost:8000/ || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Container names extracted: ['django-app']
Checking container health (elapsed: 00:00:000.00)"starting"
Checking container health (elapsed: 00:00:002.03)"starting"
Checking container health (elapsed: 00:00:004.07)"starting"
Checking container health (elapsed: 00:00:006.11)"healthy"
2025-03-05 21:18:23 INFO     [resources/base_setup_resource.py:214]
Container 'django-app' is healthy.
2025-03-05 21:18:25 INFO     [resources/base_setup_resource.py:228]
All containers are healthy.
