### PR TITLE
enforce healthy containers

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -155,7 +155,7 @@ jobs:
                 success=0
                 while [ $elapsed -lt $TIMEOUT ]; do
                   status=$(docker inspect --format '{{.State.Health.Status}}' "$container" 2>/dev/null)
-                  if [ "$status" != "starting" ]; then
+                  if [ "$status" == "healthy" ]; then
                     success=1
                     break
                   fi


### PR DESCRIPTION
The current check_server_ready just validates the container isn't starting. So, containers that are "unhealthy" are passing. This shouldn't be the case