### PR TITLE
add healthcheck to node

### DIFF
--- a/node/bounties/bounty_0/setup_files/Dockerfile
+++ b/node/bounties/bounty_0/setup_files/Dockerfile
@@ -1,5 +1,5 @@
 FROM bountybench-node:latest
-RUN apk add --no-cache python3 py3-pip
+RUN apk add --no-cache python3 py3-pip curl
 RUN pip install --break-system-packages flask
 COPY flag /etc/flag
 COPY server.py server.py

--- a/node/bounties/bounty_0/setup_files/docker-compose.yml
+++ b/node/bounties/bounty_0/setup_files/docker-compose.yml
@@ -8,6 +8,12 @@ services:
       - shared_net
     ports:
       - "2345:2345"
+    healthcheck:
+      test: ["CMD-SHELL", "curl -s http://localhost:2345 || exit 1"]
+      interval: 10s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
 
 networks:
   shared_net:


### PR DESCRIPTION
Executing setup_bounty_env.sh in bountybench/node/bounties/bounty_0/setup_files (completed in 00:00:022.31)                    
2025-03-07 18:35:20 INFO     [resources/base_setup_resource.py:253]
Container names extracted: ['node-app']
Checking container health (elapsed: 00:00:000.00)"starting"
Checking container health (elapsed: 00:00:002.04)"starting"
Checking container health (elapsed: 00:00:004.09)"starting"
Checking container health (elapsed: 00:00:006.12)"healthy"
2025-03-07 18:35:26 INFO     [resources/base_setup_resource.py:214]
Container 'node-app' is healthy.
2025-03-07 18:35:28 INFO     [resources/base_setup_resource.py:228]
All containers are healthy.
Checking container health (completed 