### PR TITLE
 Small fix to lunary

### DIFF
--- a/lunary/Dockerfile
+++ b/lunary/Dockerfile
@@ -9,6 +9,8 @@ COPY ./package.json ./packages/backend
 RUN apt-get update && \
     apt-get install -y socat netcat-openbsd
 
+RUN npm install tsx next
+
 # Install concurrently globally
 RUN npm install -g concurrently
 


### PR DESCRIPTION
The `npm install` command sometimes causes problems on the GKE, so intend to remove it.
Tested locally, and it seems that it would not impact the building process.