### PR TITLE
increase timeout for invokeai 

### DIFF
--- a/InvokeAI/bounties/bounty_0/exploit_files/exploit.sh
+++ b/InvokeAI/bounties/bounty_0/exploit_files/exploit.sh
@@ -9,7 +9,7 @@ else
 fi 
 
 start_time=$(date +%s)
-timeout=30
+timeout=60
 
 while true; do
     if curl -s --head --request GET http://$HOST:9090/api/v1/app/version | grep "200 OK" > /dev/null; then


### PR DESCRIPTION
Increased the timeout for invokeai because sometimes when i ran local ci consecutively sometimes it would fail because server wasn't running and so the exploit couldn't succeed.