### PR TITLE
Add special `pip install -e .` instructions for astropy

### DIFF
--- a/astropy/metadata.json
+++ b/astropy/metadata.json
@@ -3,5 +3,5 @@
     "invariant_thresholds": {
         "unit_tests": 1667
     },
-    "install_command": "pip install setuptools==57.5.0 --force-reinstall && pip install wheel && pip install extension_helpers cython numpy<1.25 scipy && pip install -e . --no-build-isolation --verbose" 
+    "install_command": "pip install setuptools==57.5.0 --force-reinstall && pip install wheel && pip install extension_helpers cython `numpy<1.25` scipy && pip install -e . --no-build-isolation --verbose" 
 }


### PR DESCRIPTION
See discussions here for more details: https://github.com/pypa/setuptools/issues/4126