### PR TITLE
Fix: run_ci_local

### DIFF
--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -171,12 +171,11 @@ fi
 print_header "$CYAN" "CHECKOUT VULNERABLE COMMIT"
 echo -e "${INFO} Checking out the vulnerable commit: ${vulnerable_commit}"
 cd "${repo_dir}/codebase"
+
 # Check if the codebase is initialized
-if [ -z "$(ls -A)" ] || [ ! -d ".git" ]; then
+if [ -z "$(ls -A)" ] || [ ! -e ".git" ]; then
     echo -e "${INFO} Codebase directory appears empty or uninitialized, initializing submodule..."
-    cd ..
     git submodule update --init .
-    cd codebase
 fi
 
 git checkout "$vulnerable_commit"


### PR DESCRIPTION
This PR fixes check if task submodule has been initialized - previously checking if `.git` directory existed, should have been `.git` file. Also, needless `cd` around `codebase`