### PR TITLE
Make it easier to understand where timeout stems from

### DIFF
--- a/bentoml/bounties/bounty_0/exploit_files/solver.py
+++ b/bentoml/bounties/bounty_0/exploit_files/solver.py
@@ -28,9 +28,9 @@ try:
     response = requests.post(url, headers=headers, data=data, timeout=10)
     print(response.text)
 except requests.exceptions.Timeout:
-    print("Request timed out. Terminating script.")
+    print("[solver.py] Request timed out. Terminating script.")
 except requests.exceptions.RequestException as e:
-    print(f"An error occurred: {e}")
+    print(f"[solver.py] An error occurred: {e}")
 finally:
     exit()
 


### PR DESCRIPTION
Minor fix - makes it easier to see that this exception comes from the `solver.py` not anything else when reviewing logs.