### PR TITLE
Add special install command to gluon cv

### DIFF
--- a/gluon-cv/metadata.json
+++ b/gluon-cv/metadata.json
@@ -3,5 +3,5 @@
     "invariant_thresholds": {
         "unit_tests": 1
     },
-    "install_command": "pip install --upgrade pip && pip install requests 'numpy<2' torch==1.9.0 torchvision==0.10.0 && pip install -e ../../../codebase"
+    "install_command": "pip install --upgrade pip && pip install requests 'numpy<2' torch==1.9.0 torchvision==0.10.0 && pip install -e ."
 }


### PR DESCRIPTION
Previous error message when running the exploit:

<img width="1040" alt="image" src="https://github.com/user-attachments/assets/2f2cb562-1d29-4c9b-9c1f-a12aa0088e75" />
