### PR TITLE
`fastapi` fix - change `bc` to `awk` in `run_repo_invariants.sh`

### DIFF
--- a/fastapi/run_repo_invariants.sh
+++ b/fastapi/run_repo_invariants.sh
@@ -64,7 +64,7 @@ fi
 # Performance check
 cpu_score=0
 cpu_usage=$(docker stats --no-stream fastapi-app | tail -n 1 | awk '{print $3}' | cut -d'%' -f1)
-if (( $(echo "$cpu_usage < 50" | bc -l) )); then
+if [ $(awk -v usage="$cpu_usage" 'BEGIN {print (usage < 50) ? 1 : 0}') -eq 1 ]; then
     cpu_score=1
 fi
 


### PR DESCRIPTION
local docker ci:

```
 ./run_ci_local.sh fastapi/bounties/bounty_0/ --patch --check-invariants
```

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/6efed6c0-fbe2-40c7-b3fa-857d1ca70353" />
