### PR TITLE
use verify_files instead of verify.sh for CI

### DIFF
--- a/create_bounty.sh
+++ b/create_bounty.sh
@@ -130,10 +130,12 @@ EOF
   chmod +x "$SETUP_BOUNTY_SCRIPT"
 fi
 
-#    9e. verify.sh
-VERIFY_SCRIPT="$BOUNTIES_DIR/$NEW_BOUNTY_FOLDER/verify.sh"
+#    9e. verify_files with verify.sh
+VERIFY_DIR="$BOUNTIES_DIR/$NEW_BOUNTY_FOLDER/verify_files"
+mkdir -p "$VERIFY_DIR"
+VERIFY_SCRIPT="$VERIFY_DIR/verify.sh"
 if [ ! -f "$VERIFY_SCRIPT" ]; then
-  echo "Creating verify.sh..."
+  echo "Creating verify_files/verify.sh..."
   cat <<'EOF' > "$VERIFY_SCRIPT"
 #!/bin/bash
 EOF

--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -34,7 +34,8 @@ validate_schema() {
         "bounties"
         "bounties/bounty_${bounty_number}"
         "bounties/bounty_${bounty_number}/bounty_metadata.json"
-        "bounties/bounty_${bounty_number}/verify.sh"
+        "bounties/bounty_${bounty_number}/verify_files"
+        "bounties/bounty_${bounty_number}/verify_files/verify.sh"
         "bounties/bounty_${bounty_number}/exploit_files"
         "bounties/bounty_${bounty_number}/exploit_files/exploit.sh"
         "bounties/bounty_${bounty_number}/patch_files"
@@ -54,7 +55,8 @@ validate_schema() {
             echo -e "${INFO} │   ├── bounties/"
             echo -e "${INFO} │   │   ├── bounty_${bounty_number}/"
             echo -e "${INFO} │   │   │   ├── bounty_metadata.json"
-            echo -e "${INFO} │   │   │   ├── verify.sh"
+            echo -e "${INFO} │   │   │   ├── verify_files/"
+            echo -e "${INFO} │   │   │   │   └── verify.sh"
             echo -e "${INFO} │   │   │   └── exploit_files/"
             echo -e "${INFO} │   │   │       └── exploit.sh"
             echo -e "${INFO} │   │   │   └── patch_files/"
@@ -205,7 +207,7 @@ fi
 
 exploit_dir="${bounty_dir}/exploit_files"
 exploit_script="${exploit_dir}/exploit.sh" 
-verify_script=$(find "${bounty_dir}" -type f -name "verify.sh" | head -n 1)
+verify_script="${bounty_dir}/verify_files/verify.sh"
 
 
 if [[ -z "$exploit_script" ]]; then
@@ -216,11 +218,11 @@ fi
 
 if [[ -z "$verify_script" ]]; then
     print_header "$RED" "ERROR"
-    echo -e "${ERROR} Could not find verify.sh in ${bounty_dir}"
+    echo -e "${ERROR} Could not find verify.sh in ${bounty_dir}/verify_files"
     exit 1
 fi
 
-verify_dir=$(dirname "$verify_script")
+verify_dir="${bounty_dir}/verify_files"
 
 
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -52,13 +52,13 @@ def run_exploit_script(bounty_dir, docker_helper):
 
 
 def run_verify_script(path):
-    # Find the relative path to the verify.sh from the given path
-    verify_path = find_path(path, 'verify.sh')
-
-    # Run the verify script and capture the exit code
+    # Use verify.sh from verify_files directory
+    verify_files_path = os.path.join(path, "verify_files")
+    
+    # Run the verify script from verify_files directory
     verify_result = subprocess.run(
         ["bash", "./verify.sh"],
-        cwd=path + "/" + verify_path,
+        cwd=verify_files_path,
         capture_output=True,
         text=True
     )


### PR DESCRIPTION
There's no good mechanism for collecting verify.sh and related files, which is now needed in exploit workflow. Copying over files to verify_files.

Overall plan add robust CI / documentation, then update bounties accordingly

https://github.com/cybench/bountyagent/pull/755