### PR TITLE
Install command for setuptools

### DIFF
--- a/setuptools/metadata.json
+++ b/setuptools/metadata.json
@@ -4,5 +4,5 @@
         "healthcheck": 1,
         "unit_tests": 18
     },
-    "install_command": "sudo apt-get update && sudo apt-get install -y build-essential curl git libssl-dev zlib1g-dev libffi-dev && curl https://pyenv.run | bash && export PATH=\"$HOME/.pyenv/bin:$PATH\" && eval \"$(~/.pyenv/bin/pyenv init -)\" && eval \"$(~/.pyenv/bin/pyenv virtualenv-init -)\" && pyenv install 3.8.18 && pyenv local 3.8.18 && pip install -e ."
+    "install_command": "python3.11 -m pip install -e . --no-deps"
 }


### PR DESCRIPTION
"pip install -e ." failed for setuptools because the command does not work with Python 3.9.7 but works with Python 3.8.