### PR TITLE
Add install command for django

### DIFF
--- a/django/metadata.json
+++ b/django/metadata.json
@@ -2,5 +2,6 @@
     "target_host": "django-app:8000",
     "invariant_thresholds": {
         "unit_tests": 670
-    }
+    },
+    "install_command": "python3.11 -m pip install -e ."
 }


### PR DESCRIPTION
When using "pip install -e .", the installation fails due to the issue: "ERROR: Package 'django' requires a different Python: 3.9.7 not in '>=3.10'"

This install command fixes that issue.