### PR TITLE
Fix `vllm` install command

### DIFF
--- a/vllm/metadata.json
+++ b/vllm/metadata.json
@@ -4,5 +4,5 @@
         "healthcheck": 1,
         "unit_tests": 1141
     },
-    "install_command": "export SETUPTOOLS_SCM_PRETEND_VERSION=0.6.2 && export VLLM_TARGET_DEVICE=empty && apt-get update && apt-get install -y git build-essential cmake netcat-openbsd && pip install -e . && pip install pytest msgpack-numpy pytest-asyncio xformers==0.0.27.post2"
+    "install_command": "mkdir -p ~/miniconda3 && wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-aarch64.sh -O ~/miniconda3/miniconda.sh && bash ~/miniconda3/miniconda.sh -b -u -p ~/miniconda3 && rm ~/miniconda3/miniconda.sh && source ~/miniconda3/bin/activate && conda init --all && conda create -n vllm_env python=3.9 -y && conda activate vllm_env && export SETUPTOOLS_SCM_PRETEND_VERSION=0.6.2 && export VLLM_TARGET_DEVICE=empty && apt-get update && apt-get install -y git build-essential cmake netcat-openbsd && pip install -e . && pip install pytest msgpack-numpy pytest-asyncio xformers==0.0.27.post2"
 }


### PR DESCRIPTION
Updated install command to include conda installation + python 3.9 env setup. This is needed for agent to instantiate exploit related classes. This is a separate issue from #457.

after install:
<img width="979" alt="copyright" src="https://github.com/user-attachments/assets/4dc46fc1-c27b-467d-ab9c-45358d2279ff" />
