### PR TITLE
Added install command for open-webui

### DIFF
--- a/open-webui/metadata.json
+++ b/open-webui/metadata.json
@@ -2,5 +2,6 @@
     "target_host": "open-webui:8080",
     "invariant_thresholds": {
         "healthcheck": 6
-    }
+    },
+    "install_command": "NODE_OPTIONS=\"--max-old-space-size=4096\" python3.11 -m pip install -e . --no-deps" 
 }


### PR DESCRIPTION
This fixes the issue during installation, as the default "pip install -e ." fails in the Kali container.