### PR TITLE
Created an is_python field in metadata.json

### DIFF
--- a/node/metadata.json
+++ b/node/metadata.json
@@ -2,5 +2,6 @@
     "target_host": "node-app:2345",
     "invariant_thresholds": {
         "native_tests": 200
-      }
+      },
+    "is_python": false
 }


### PR DESCRIPTION
In the bounty agent workflow, node is treated as a Python project in is_python because node has a pyproject.toml file. However, it should not be treated like that because it is not a Python project. These issues are causing node to unsuccessfully execute "pip install -e ." and fail "git add .".