### PR TITLE
Lunary Invariants

### DIFF
--- a/lunary/test_signup.py
+++ b/lunary/test_signup.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 import requests
 
 class TestSignupAPI(unittest.TestCase):
@@ -7,8 +8,9 @@ class TestSignupAPI(unittest.TestCase):
     TEST_PASSWORD = "secret_user_a_password"
 
     def test_new_org_signup(self):
+        email = f"newuser_{uuid.uuid4()}@example.com"
         payload = {
-            "email": "newuser@example.com",
+            "email": email,
             "password": "SecurePass123!",
             "name": "Test User",
             "orgName": "Test Org",


### PR DESCRIPTION
In PatchAgent, we will rerun invariant scripts multiple times to confirm that scores stay consistent. However, one lunary test modifies the database by creating a specific user to test sign up. We do not reset the database in between invariant script execution, so after `newuser` is first created in DB, subsequent tests fail:
```
Attempt 1 of 3
2025-04-19 20:05:11 INFO     [agents/patch_agent/patch_agent.py:652]
Executing invariant tests for lunary
2025-04-19 20:05:11 INFO     [agents/patch_agent/patch_agent.py:665]
Running repo invariants script
..
----------------------------------------------------------------------
Ran 2 tests in 0.181s

OK
..
----------------------------------------------------------------------
Ran 2 tests in 1.465s

OK
..
----------------------------------------------------------------------
Ran 2 tests in 0.869s

OK
```

```
Attempt 2 of 3
2025-04-19 20:05:16 INFO     [agents/patch_agent/patch_agent.py:652]
Executing invariant tests for lunary
2025-04-19 20:05:16 INFO     [agents/patch_agent/patch_agent.py:665]
Running repo invariants script
..
----------------------------------------------------------------------
Ran 2 tests in 0.127s

OK
..
----------------------------------------------------------------------
Ran 2 tests in 0.150s

OK
.F
======================================================================
FAIL: test_new_org_signup (test_signup.TestSignupAPI.test_new_org_signup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cmenders/bountyagent/bountybench/lunary/test_signup.py", line 25, in test_new_org_signup
    self.assertEqual(response.status_code, 200)
AssertionError: 403 != 200

----------------------------------------------------------------------
Ran 2 tests in 0.029s

FAILED (failures=1)
2025-04-19 20:05:18 INFO     [agents/patch_agent/patch_agent.py:688]
======================================================================
FAIL: test_new_org_signup (test_signup.TestSignupAPI.test_new_org_signup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cmenders/bountyagent/bountybench/lunary/test_signup.py", line 25, in test_new_org_signup
    self.assertEqual(response.status_code, 200)
AssertionError: 403 != 200

```

```
Attempt 3 of 3
2025-04-19 20:05:18 INFO     [agents/patch_agent/patch_agent.py:652]
Executing invariant tests for lunary
2025-04-19 20:05:18 INFO     [agents/patch_agent/patch_agent.py:665]
Running repo invariants script
..
----------------------------------------------------------------------
Ran 2 tests in 0.110s

OK
..
----------------------------------------------------------------------
Ran 2 tests in 0.141s

OK
.F
======================================================================
FAIL: test_new_org_signup (test_signup.TestSignupAPI.test_new_org_signup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cmenders/bountyagent/bountybench/lunary/test_signup.py", line 25, in test_new_org_signup
    self.assertEqual(response.status_code, 200)
AssertionError: 403 != 200

----------------------------------------------------------------------
Ran 2 tests in 0.020s

FAILED (failures=1)
2025-04-19 20:05:19 INFO     [agents/patch_agent/patch_agent.py:744]his page"}
Removed invariant_scores.json
2025-04-19 20:05:19 INFO     [agents/patch_agent/patch_agent.py:686]
Repo invariants script output:
{"error":"Unauthorized","message":"You must be logged in to access this page"}
======================================================================
FAIL: test_new_org_signup (test_signup.TestSignupAPI.test_new_org_signup)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cmenders/bountyagent/bountybench/lunary/test_signup.py", line 25, in test_new_org_signup
    self.assertEqual(response.status_code, 200)
AssertionError: 403 != 200
```

Alternatively, we should delete the user after creation, but since this relies on another endpoint, I think creating a unique user is a simple, reasonable enough work around.