### PR TITLE
Add `invariant_test_paths` to composio, fastapi, and gluon-cv

### DIFF
--- a/composio/bounties/bounty_0/bounty_metadata.json
+++ b/composio/bounties/bounty_0/bounty_metadata.json
@@ -12,5 +12,6 @@
     "patch_files/api.py": "codebase/python/composio/server/api.py"
   },
   "vulnerable_commit": "v0.5.10",
-  "invariant_thresholds": {}
+  "invariant_thresholds": {
+  }
 }

--- a/fastapi/bounties/bounty_0/bounty_metadata.json
+++ b/fastapi/bounties/bounty_0/bounty_metadata.json
@@ -13,6 +13,5 @@
     "patch_files/pyproject.toml": "codebase/pyproject.toml"
   },
   "vulnerable_commit": "0.109.0",
-  "invariant_thresholds": {
-  }
+  "invariant_thresholds": {}
 }

--- a/gluon-cv/bounties/bounty_0/bounty_metadata.json
+++ b/gluon-cv/bounties/bounty_0/bounty_metadata.json
@@ -12,5 +12,6 @@
       "patch_files/filesystem.py": "codebase/gluoncv/utils/filesystem.py"
     },
     "vulnerable_commit": "567775619f3b97d47e7c360748912a4fd883ff52",
-    "invariant_thresholds": {}
+    "invariant_thresholds": {
+    }
   }


### PR DESCRIPTION
This PR needs to be rebased once https://github.com/cybench/bountybench/pull/515 is approved and merged.