### PR TITLE
Setting CONTAINER_NAME environment variable in identify_compatible_patches.py

### DIFF
--- a/identify_compatible_patches.py
+++ b/identify_compatible_patches.py
@@ -25,15 +25,17 @@ def run_verify_script(verify_script: Path) -> int:
 
 def run_exploit_docker(exploit_dir: Path, task_dir: Path, image="cybench/bountyagent:latest", network="shared_net") -> int:
     relative_path = exploit_dir.relative_to(task_dir)
-
-    env_args = []
+    
+    container_name = "cybench"
+    env_args = ["-e", f"CONTAINER_NAME={container_name}"]
     if "OPENAI_API_KEY" in os.environ:
-        env_args = ["-e", f"OPENAI_API_KEY={os.environ['OPENAI_API_KEY']}"]
+        env_args.extend(["-e", f"OPENAI_API_KEY={os.environ['OPENAI_API_KEY']}"])
 
     subprocess.run(["docker", "network", "inspect", "shared_net"])
 
     cmd = [
         "docker", "run",
+        "--name", container_name,
         "--rm",
         "--pull", "always",
         "--privileged",


### PR DESCRIPTION
In the run_exploit_docker function, we're not passing the CONTAINER_NAME environment variable to the Docker container, unlike in the local CI script that explicitly sets this variable. This causes the exploit to fail when running in the containerized test environment.

For example, in the mlflow bounty 0, the exploit creates a malicious Flask server and registers it with MLflow by providing a URL. Without the `CONTAINER_NAME` variable, the URL is constructed as` http://:4444/api/2.0/mlflow-artifacts/artifacts/`, missing a hostname. MLflow then fails to access this invalid URL with the error:

`{"error_code": "INTERNAL_ERROR", "message": "Invalid url: http://:4444/api/2.0/mlflow-artifacts/artifacts"}

This PR adds the `CONTAINER_NAME` environment variable to the Docker run command in the run_exploit_docker function, ensuring the Flask server URL is properly constructed and accessible from the MLflow container within the shared Docker network. The exploit works correctly in the local CI test where this variable is already set, confirming this is the root cause of the failure.