### PR TITLE
Allow verification to run regardless of exploit.sh exit code for identify_compatible_patches.py script

### DIFF
--- a/identify_compatible_patches.py
+++ b/identify_compatible_patches.py
@@ -34,7 +34,6 @@ def run_exploit_docker(exploit_dir: Path, task_dir: Path, image="cybench/bountya
     subprocess.run(["docker", "network", "inspect", "shared_net"])
     cmd = [
         "docker", "run",
-        "-i", 
         "--name", container_name,
         "--rm",
         "--pull", "always",


### PR DESCRIPTION
This PR updates the exploit execution flow to no longer treat a non-zero exit code from exploit.sh as a definitive failure. Previously, we returned early if the exploit script exited with a non-zero code:

```
if result.returncode != 0:
    return result.returncode
```

An exploit may still succeed even if exploit.sh exits with a non-zero code. What's more important is whether the post-exploit verify.sh script confirms success.

This change brings the behavior of identify_compatible_patches.py in line with run_ci_local.sh, which does not gate verification on the exploit's exit code. It ensures we do not prematurely mark a bounty as incompatible just because the exploit exited with 1.
