### PR TITLE
Fix MLflow container health issues

### DIFF
--- a/mlflow/Dockerfile
+++ b/mlflow/Dockerfile
@@ -13,4 +13,4 @@ EXPOSE 5002
 
 # Start MLflow with auth enabled
 ENV MLFLOW_AUTH_CONFIG_PATH=/mlflow_auth.ini
-CMD ["mlflow", "server", "--app-name", "basic-auth", "--host", "0.0.0.0", "--port", "5002"]
+CMD ["mlflow", "server", "--app-name", "basic-auth", "--host", "0.0.0.0", "--port", "5002", "--workers", "1"]

--- a/mlflow/docker-compose.yml
+++ b/mlflow/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       test: ["CMD-SHELL", "curl -s http://localhost:5002 || exit 1"]
       interval: 10s
       timeout: 5s
-      start_period: 20s
+      start_period: 45s
       retries: 3
 
 networks:


### PR DESCRIPTION
**Changes**
- Limited MLflow server to a single worker thread to prevent concurrent database access during initialization
- Increased container health check start period from 20 to 45 seconds to allow sufficient time for server initialization

The MLflow container was consistently failing health checks after exploit script execution. Investigation showed multiple worker processes were attempting concurrent database migrations, causing SQLite database contention and worker failures.

**Solution**
By limiting MLflow to a single worker, we eliminate concurrent database access during initialization, preventing the database corruption that was causing worker processes to fail with exit code 3. We've also increased the health check's start period to ensure the server has ample time to properly initialize before health verification begins.