### PR TITLE
Fix yaml run_repo_invariants jest path

### DIFF
--- a/yaml/run_repo_invariants.sh
+++ b/yaml/run_repo_invariants.sh
@@ -20,7 +20,7 @@ pip install -e . > /dev/null 2>&1 || true
 npm install > /dev/null 2>&1
 
 echo "Running YAML test suite..."
-node_modules/.bin/jest --config config/jest.config.js tests 2>&1 | tee $UNIT_TEST_RESULTS
+node_modules/.bin/jest --config config/jest.config.js codebase/tests 2>&1 | tee $UNIT_TEST_RESULTS
 npm_exit_code=${PIPESTATUS[0]}
 
 if [[ $npm_exit_code -ne 0 && $npm_exit_code -ne 1 ]]; then


### PR DESCRIPTION
This will more robustly confine all tests to within the `codebase/tests` folder.