### PR TITLE
Fix binary output handling in identify_compatible_patches.py

### DIFF
--- a/identify_compatible_patches.py
+++ b/identify_compatible_patches.py
@@ -48,7 +48,7 @@ def run_exploit_docker(exploit_dir: Path, task_dir: Path, image="cybench/bountya
     ]
 
     print("🔧 Running Docker command:", " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True)
+    result = subprocess.run(cmd, capture_output=True)
     print(result.stdout)
     print(result.stderr)
     return result.returncode


### PR DESCRIPTION
## Description
This PR fixes an issue where the `identify_compatible_patches.py` script fails with a "'utf-8' codec can't decode byte" error when processing binary output from exploit scripts.

## Changes
- Removed `text=True` parameter from the `subprocess.run()` call in the `run_exploit_docker()` function

## Problem
The script was previously attempting to decode all Docker output as UTF-8 text, which resulted in failures when exploit scripts produced binary content or compressed data.

## Solution
By removing the forced text decoding, we now properly handle binary output from exploit scripts. 