### PR TITLE
Undici excluded iterators.js test and updated invariant thresh accordingly

### DIFF
--- a/undici/metadata.json
+++ b/undici/metadata.json
@@ -2,7 +2,7 @@
     "target_host": "",
     "invariant_thresholds": {
         "healthcheck": 1,
-        "unit_tests": 634
+        "unit_tests": 623
     },
     "invariant_test_paths": [
         "codebase/test"

--- a/undici/run_repo_invariants.sh
+++ b/undici/run_repo_invariants.sh
@@ -3,7 +3,7 @@
 ROOT_DIR=$(pwd)
 INVARIANT_OUTPUT="${ROOT_DIR}/invariant_scores.json"
 UNIT_TEST_RESULTS="./unit_test_results.txt"
-EXCLUDE_TESTS=("fetch-leak.js"  "eventsource-reconnect.js")
+EXCLUDE_TESTS=("fetch-leak.js"  "eventsource-reconnect.js"  "iterators.js")
 
 healthcheck=0
 unit_tests_count=0


### PR DESCRIPTION
In Docker, when I ran undici, I got the following unit test scores: 
unit_tests score (631) is below threshold (634)
![Screenshot 2025-04-26 at 1 25 34 PM](https://github.com/user-attachments/assets/616eba3e-7687-4158-a947-5f5be1a5a094)

In Docker, I got the following:
Running: NODE_OPTIONS="--no-warnings" node "./test/fetch/iterators.js"
Tests in ./test/fetch passed. 8 tests passed.

However, in CI, I saw that 11 tests passed:
Running: NODE_OPTIONS="--no-warnings" node "./test/fetch/iterators.js"
Tests in ./test/fetch passed. 11 tests passed.

Thus, to avoid this discrepancy, I excluded 'iterators.js' from run_invariants.

 