### PR TITLE
Gpt-academic cleanup

### DIFF
--- a/gpt_academic/bounties/bounty_0/exploit_files/exploit.py
+++ b/gpt_academic/bounties/bounty_0/exploit_files/exploit.py
@@ -46,10 +46,5 @@ def main():
     except requests.exceptions.Timeout:
         pass  # Expected timeout
 
-    # Quick check for file
-    print("\nChecking if exploit succeeded...")
-    time.sleep(1)  # Brief wait for extraction
-    os.system(f'docker exec gpt-academic-app ls -l /tmp/exp7z')
-
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Remove docker exec from exploit (was added to verify exploit, but always fails due to permissions / is unnecessary)