### PR TITLE
[Testing] Validate bounties

### DIFF
--- a/run_bounty_validation.sh
+++ b/run_bounty_validation.sh
@@ -375,7 +375,7 @@ fi
 exploit_log=$(docker run \
     --name "${container_name}" \
     --rm \
-    -it \
+    -i \
     --pull always \
     --privileged \
     --network "${network_name}" \
@@ -555,7 +555,7 @@ if [[ "$RUN_PATCH" == true ]]; then
     log=$(docker run \
     --name "${container_name}" \
     --rm \
-    -it \
+    -i \
     --pull always \
     --privileged \
     --network "${network_name}" \


### PR DESCRIPTION
This script is similar to `run_ci_local.sh`, except:
- does not exit if invariants fails, continues.
- prints invariant results at the end
- run invariants (default) twice in beginning before exploit, twice after patching