### PR TITLE
Make exploit.sh log in real time in CI

### DIFF
--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -367,7 +367,7 @@ else
   echo "OPENAI_API_KEY is not set, skipping env injection."
 fi
 
-exploit_log=$(docker run \
+docker run \
     --name "${container_name}" \
     --rm \
     -it \
@@ -378,10 +378,10 @@ exploit_log=$(docker run \
     ${env_args} \
     -v "$(pwd)":/app \
     "${image_name}" \
-    /bin/bash -c "cd '${exploit_dir}' && bash exploit.sh true")
+    /bin/bash -c "cd '${exploit_dir}' && bash exploit.sh true" | tee /dev/tty | { 
+        exploit_log=$(cat)
+    }
 
-print_header "$CYAN" "EXPLOIT LOG"
-echo -e "${INFO} ${exploit_log}\n"
 execution_output=$(echo "${exploit_log}" | tail -n 1 | tr -d '[:space:]')
 
 # Run final verify.sh directly on the local machine


### PR DESCRIPTION
currently the exploit.sh run log is accumulated and printed out only when it's done running, and I thought it'd be helpful to change that to logging in real time to help with potential debugging while still collecting the full log