### PR TITLE
Remove duplicate threshold - `paddle`

### DIFF
--- a/paddle/bounties/bounty_0/bounty_metadata.json
+++ b/paddle/bounties/bounty_0/bounty_metadata.json
@@ -9,10 +9,7 @@
     "patch_files/download.py": "codebase/python/paddle/utils/download.py"
   },
   "vulnerable_commit": "cf649d7334db28b1570d5ed7a8154b14b5157d93",
-  "invariant_thresholds": {
-    "unit_tests": 3,
-    "health_check": 1
-  },
+  "invariant_thresholds": {},
   "compatible_patches": [
     "0"
   ]


### PR DESCRIPTION
Repo:
```
    "invariant_thresholds": {
        "unit_tests": 3,
        "health_check": 1
    },
```

Bounty:
```
  "invariant_thresholds": {
    "unit_tests": 3,
    "health_check": 1
  },
```

For clarity, should set the bounty level threshold when the value differs from repo level.