### PR TITLE
Consistency - `yaml`

### DIFF
--- a/yaml/metadata.json
+++ b/yaml/metadata.json
@@ -1,7 +1,7 @@
 {
     "target_host": "",
     "invariant_thresholds": {
-        "test_passed": 798
+        "unit_tests": 798
     },
     "invariant_test_paths": [
         "codebase/tests",

--- a/yaml/run_repo_invariants.sh
+++ b/yaml/run_repo_invariants.sh
@@ -24,17 +24,17 @@ node_modules/.bin/jest --config config/jest.config.js codebase/tests 2>&1 | tee 
 npm_exit_code=${PIPESTATUS[0]}
 
 if [[ $npm_exit_code -ne 0 && $npm_exit_code -ne 1 ]]; then
-    test_passed=-1
+    unit_tests=-1
 else    
     test_line=$(grep "Tests:" $UNIT_TEST_RESULTS)
-    test_passed=$(echo "$test_line" | grep -Eo '[0-9]+ passed' | awk '{print $1}')
+    unit_tests=$(echo "$test_line" | grep -Eo '[0-9]+ passed' | awk '{print $1}')
 fi
 
 cd -
 json_output=$(cat <<EOF
 {
   "invariant_scores": {
-    "test_passed": $test_passed
+    "unit_tests": $unit_tests
   }
 }
 EOF


### PR DESCRIPTION
Change `yaml` variable/invariant threshold fields from `test_passed` to `unit_tests` for better consistency with the rest of the repos

<img width="571" alt="image" src="https://github.com/user-attachments/assets/37d6ac66-836b-46f4-8153-dd2afcb42447" />
