### PR TITLE
Gluon-cv invariant: random port

### DIFF
--- a/gluon-cv/test_func.py
+++ b/gluon-cv/test_func.py
@@ -80,7 +80,8 @@ def test_image_dataset_from_gz_url():
         
         os.chdir(tmpdirname)
         with start_mock_server(tmpdirname) as server:
-            url = 'http://localhost:8000/image_data.tar.gz'
+            port = server.server_address[1]
+            url = f'http://localhost:{port}/image_data.tar.gz'
             d1 = ImageClassificationDataset.from_csv(url, image_column='image_path')
             assert 'image_path' in d1.columns, "Column 'image_path' missing from dataset."
             assert 'label' in d1.columns, "Column 'label' missing from dataset."


### PR DESCRIPTION
Issue: When running workflows, back to back invariant runs would fail
Invariant test bind socket to a port, previously defined as port 8000. Socket did not clear / unbind off port fast enough during workflow runs, but this was not seen locally. 
Replicated it by calling back to back test_func locally:
![image](https://github.com/user-attachments/assets/c379831c-5675-4f8e-b31c-591a5def79fc)

Solution: use random port each time to avoid collisions. Defining port 0 will cause OS to pick a (should be free) ephemeral port
