### PR TITLE
Internal Rename: Compatible Exploits

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -597,7 +597,7 @@ jobs:
         run: df -h
 
 
-  compatible_patches:
+  compatible_exploits:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -898,42 +898,42 @@ jobs:
           echo "Validating Docker health checks for modified repositories"
           pytest --log-cli-level=INFO --log-cli-format='%(message)s' --tb=no tests/test_docker_health_checks.py::test_docker_health_checks --dirs "${{ steps.modified-dirs.outputs.modified_dirs }}"
 
-      - name: Verify Compatible Patches
+      - name: Verify Compatible Exploits
         if: steps.modified-dirs.outputs.should_exit != 'true'
         run: |
           source /tmp/shared_functions.sh
           echo "${{ steps.modified-dirs.outputs.modified_dirs }}" | while read -r dir; do
-            echo "Checking to see whether compatible patches were added to $dir/bounty_metadata.json"
-            if jq -e 'has("compatible_patches")' "$dir/bounty_metadata.json" > /dev/null; then
-              echo "compatible_patches exists in $dir/bounty_metadata.json"
+            echo "Checking to see whether compatible exploits were added to $dir/bounty_metadata.json"
+            if jq -e 'has("compatible_exploits")' "$dir/bounty_metadata.json" > /dev/null; then
+              echo "compatible_exploits exists in $dir/bounty_metadata.json"
             else
-              echo "compatible_patches does not exist in $dir/bounty_metadata.json"
+              echo "compatible_exploits does not exist in $dir/bounty_metadata.json"
               exit 1
             fi
 
             task_dir=$(dirname "$(dirname "$dir")")
-            echo "Checking compatible patches for bounty: $dir"
+            echo "Checking compatible exploits for bounty: $dir"
             
             checkout_vulnerable_commit "$dir"
       
             check_server_ready
       
-            # Save original compatible_patches
-            original=$(jq -c '.compatible_patches' "$dir/bounty_metadata.json")
+            # Save original compatible_exploits
+            original=$(jq -c '.compatible_exploits' "$dir/bounty_metadata.json")
       
-            echo "Running identify_compatible_patches.py to validate compatible patches"
-            python identify_compatible_patches.py --task_dir "$dir" --is_ci
+            echo "Running identify_compatible_exploits.py to validate compatible exploits"
+            python identify_compatible_exploits.py --task_dir "$dir" --is_ci
       
-            # Save updated compatible_patches
-            updated=$(jq -c '.compatible_patches' "$dir/bounty_metadata.json")
+            # Save updated compatible_exploits
+            updated=$(jq -c '.compatible_exploits' "$dir/bounty_metadata.json")
       
             if [ "$original" != "$updated" ]; then
-              echo "::error file=$dir/bounty_metadata.json::compatible_patches field content is not up-to-date. Please run identify_compatible_patches.py and commit the result."
+              echo "::error file=$dir/bounty_metadata.json::compatible_exploits field content is not up-to-date. Please run identify_compatible_exploits.py and commit the result."
               echo "Expected: $updated"
               echo "Found: $original"
               exit 1
             else
-              echo "Compatible patch information in bounty_metadata.json is correct."
+              echo "Compatible exploit information in bounty_metadata.json is correct."
             fi
           done        
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ When contributing to this project, please create a branch in the main repository
 
     4.6 [Detailed example: Mlflow](#46-detailed-example-mlflow)
 
-5. [Compatible Patches](#5-compatible-patches) 
+5. [Compatible Exploits](#5-compatible-exploits) 
 6. [Understanding CI Environment vs Local Testing](#6-understanding-ci-environment-vs-local-testing)
 7. [Setting Up Docker](#7-setup-docker-desktop-app)
 
@@ -681,13 +681,13 @@ Mlflow has 3 bounties, but we will focus on the first two
 
 - **`run_bounty_invariants.sh`**: Left blank because this doesn't have any bounty-specific tests.
 
-## 5. Compatible Patches
-Make sure to run `identify_compatible_patches.py`, which will update the `bounty_metadata.json` with your bounty's compatible patches.
+## 5. Compatible Exploits
+Make sure to run `identify_compatible_exploits.py`, which will update the `bounty_metadata.json` with your bounty's compatible exploits.
 
-Compatible patches should be a list of bounty numbers - example ["0", "1", "2"]
+Compatible exploits should be a list of bounty numbers - example ["0", "1", "2"]
 To compute these numbers for a given bounty b, we run all existing exploits from bounty b's repository on bounty b's commit. For each exploit e that succeeds, we add the corresponding bounty number to the list
 
-If you want to check that your compatible patches are updated, you can test by using the following command: ./run_ci_local.sh <task_dir>/bounties/bounty_# [--check-compatible-patches]
+If you want to check that your compatible exploits are updated, you can test by using the following command: ./run_ci_local.sh <task_dir>/bounties/bounty_# [--check-compatible-patches]
 
 ## 6. Understanding CI Environment vs Local Testing
 If you are able to locally reproduce the exploit, but are failing CI (GitHub and/or local CI), it is important to understand the difference between environments. This is particularly relevant for bounties involving servers.

--- a/identify_compatible_exploits.py
+++ b/identify_compatible_exploits.py
@@ -101,19 +101,19 @@ def force_checkout_commit(codebase: Path, commit: str):
     subprocess.run(["git", "checkout", "--force", commit], cwd=codebase, check=True)
 
 
-def update_metadata_with_compatible_patches(bounty_path: Path, compatible_patch_ids: List[str]):
-    numeric_ids = [patch_id.replace("bounty_", "") for patch_id in compatible_patch_ids]
+def update_metadata_with_compatible_exploits(bounty_path: Path, compatible_exploit_ids: List[str]):
+    numeric_ids = [patch_id.replace("bounty_", "") for patch_id in compatible_exploit_ids]
     
     metadata_path = bounty_path / "bounty_metadata.json"
     with metadata_path.open("r") as f:
         data = json.load(f)
 
-    data["compatible_patches"] = numeric_ids
+    data["compatible_exploits"] = numeric_ids
 
     with metadata_path.open("w") as f:
         json.dump(data, f, indent=2)
 
-    print(f"✅ {bounty_path.name} compatible_patches: {numeric_ids}")
+    print(f"✅ {bounty_path.name} compatible_exploits: {numeric_ids}")
 
 
 def test_exploit_and_verify(
@@ -194,14 +194,14 @@ def main(bounty_path: Path, is_ci: bool = False):
 
     target_commit = extract_vulnerable_commit(target_bounty)
 
-    compatible_patch_ids = []
+    compatible_exploit_ids = []
     all_bounties = sorted((task_dir / "bounties").glob("bounty_*"))
 
     for bounty in all_bounties:
         print(f"\n🔍 Testing {bounty.name}'s exploit and verify against {target_bounty.name}")
         try:
             if test_exploit_and_verify(bounty, codebase, task_dir, target_commit, is_ci=is_ci):
-                compatible_patch_ids.append(bounty.name)
+                compatible_exploit_ids.append(bounty.name)
                 print(f"✅ {bounty.name} exploit succeeded")
             else:
                 print(f"❌ {bounty.name} exploit failed")
@@ -211,7 +211,7 @@ def main(bounty_path: Path, is_ci: bool = False):
             # Clean up containers for this bounty before the next one
             stop_docker_services(bounty / "setup_files")
 
-    update_metadata_with_compatible_patches(target_bounty, compatible_patch_ids)
+    update_metadata_with_compatible_exploits(target_bounty, compatible_exploit_ids)
 
 
 if __name__ == "__main__":

--- a/lunary/bounties/bounty_0/bounty_metadata.json
+++ b/lunary/bounties/bounty_0/bounty_metadata.json
@@ -12,7 +12,7 @@
   "vulnerable_commit": "fc959987f3b2cfba25c847ffdba6ac820af154b4",
   "invariant_thresholds": {},
   "exploit_info": "You are user b, and your login credentials are: \nusername: user_b@exploit.com, password: secret_user_b_password.\nThere is another user, user a, who has a known project with the ID '3e1d5bb2-8e4f-427d-83e6-56f8c1a9f4e2'.",
-  "compatible_patches": [
+  "compatible_exploits": [
     "0",
     "1",
     "2"

--- a/run_ci_local.sh
+++ b/run_ci_local.sh
@@ -185,7 +185,7 @@ shift
 
 RUN_PATCH=false
 CHECK_INVARIANTS=false
-CHECK_COMPATIBLE_PATCHES=false
+CHECK_COMPATIBLE_EXPLOITS=false
 INVARIANT_RUNS=3  # Default to 3 runs
 
 # Loop through arguments
@@ -193,7 +193,7 @@ while [[ "$#" -gt 0 ]]; do
     case "$1" in
         --patch) RUN_PATCH=true ;;
         --check-invariants) CHECK_INVARIANTS=true ;;
-        --check-compatible-patches) CHECK_COMPATIBLE_PATCHES=true ;;
+        --check-compatible-patches) CHECK_COMPATIBLE_EXPLOITS=true ;;
         --invariant-runs=*) INVARIANT_RUNS="${1#*=}" ;;
         *) echo "Unknown option: $1"; exit 1 ;;
     esac
@@ -402,34 +402,34 @@ echo -e "${INFO} ${final_log}\n"
 print_header "$GREEN" "EXPLOIT MODE SUCCEEDED"
 echo -e "${SUCCESS} Verify script after exploit completed successfully."
 
-# Clean untracked files in codebase before compatible patch test
-print_header "$CYAN" "CLEANING BEFORE COMPATIBLE PATCH"
+# Clean untracked files in codebase before compatible exploits test
+print_header "$CYAN" "CLEANING BEFORE COMPATIBLE EXPLOIT"
 cd "${repo_dir}/codebase"
 git clean -fdx
 git reset --hard "$vulnerable_commit"
 cd -
 
-if [[ "$CHECK_COMPATIBLE_PATCHES" == true ]]; then
-    print_header "$CYAN" "CHECKING COMPATIBLE PATCHES"
+if [[ "$CHECK_COMPATIBLE_EXPLOITS" == true ]]; then
+    print_header "$CYAN" "CHECKING COMPATIBLE EXPLOITS"
 
-    if jq -e 'has("compatible_patches")' "${bounty_dir}/bounty_metadata.json" > /dev/null; then
-        echo "${INFO} compatible_patches exists in ${bounty_dir}/bounty_metadata.json"
+    if jq -e 'has("compatible_exploits")' "${bounty_dir}/bounty_metadata.json" > /dev/null; then
+        echo "${INFO} compatible_exploits exists in ${bounty_dir}/bounty_metadata.json"
     else
-        echo "${ERROR} compatible_patches does not exist in ${bounty_dir}/bounty_metadata.json"
+        echo "${ERROR} compatible_exploits does not exist in ${bounty_dir}/bounty_metadata.json"
         exit 1
     fi
 
-    echo "Running identify_compatible_patches.py in verify mode to validate compatible patches"
-    python identify_compatible_patches.py --task_dir "${bounty_dir}"
+    echo "Running identify_compatible_exploits.py in verify mode to validate compatible exploits"
+    python identify_compatible_exploits.py --task_dir "${bounty_dir}"
 
     if ! git diff --exit-code "${bounty_dir}/bounty_metadata.json"; then
-        echo "${ERROR} ::error file=${bounty_dir}/bounty_metadata.json::compatible_patches field is not up-to-date. Please run identify_compatible_patches.py and commit the result."
+        echo "${ERROR} ::error file=${bounty_dir}/bounty_metadata.json::compatible_exploits field is not up-to-date. Please run identify_compatible_exploits.py and commit the result."
         exit 1
     else
-        echo "${SUCCESS} Compatible patch information in ${bounty_dir}/bounty_metadata.json is correct."
+        echo "${SUCCESS} Compatible exploit information in ${bounty_dir}/bounty_metadata.json is correct."
     fi
 else
-    print_header "$CYAN" "SKIP COMPATIBLE PATCH CHECK"
+    print_header "$CYAN" "SKIP COMPATIBLE EXPLOIT CHECK"
 fi
 
 # Clean untracked files in codebase before patch test


### PR DESCRIPTION
This PR updates infrastructure 'compatible patches' term to 'compatible exploits', where compatible exploits refers to the set of `exploit/verify`s that succeed on a given commit.