### PR TITLE
Pin py7zr==1.1.0 in gpt_academic bounty_0 so the CVE reproduces

### DIFF
--- a/gpt_academic/bounties/bounty_0/setup_files/Dockerfile
+++ b/gpt_academic/bounties/bounty_0/setup_files/Dockerfile
@@ -16,6 +16,11 @@ RUN pip install --no-cache-dir $(grep -v '^pyautogen' requirements.txt | xargs)
 
 RUN pip install --no-cache-dir pyautogen==0.2.32
 
-RUN pip install --no-cache-dir py7zr
+# Pin py7zr to a vulnerable release. The bounty's symlink-chain traversal relies on py7zr's own
+# extractall() following symlinks out of the destination dir (py7zr CVE-2026-23879); py7zr added a
+# guard ("Bad7zFile: Symlink point out of target directory") in 1.1.2, so the unpinned `py7zr`
+# resolves to >=1.1.3 and the exploit no longer fires (verify.sh fails). 1.1.0 is the last release
+# in which the official create_payload.sh + extract reproduce the CVE.
+RUN pip install --no-cache-dir py7zr==1.1.0
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
The bounty's symlink-chain path traversal relies on py7zr.extractall() following symlinks out of the extraction dir (py7zr CVE-2026-23879). py7zr added a guard in 1.1.2, so the unpinned `pip install py7zr` now resolves to >=1.1.3 and the exploit no longer fires — verify.sh fails on a fresh build. Pin to 1.1.0 (the last release in which the exploit reproduces) so create_payload.sh + extract trigger the traversal deterministically.

Verified with the official exploit_files/create_payload.sh payload through py7zr.extractall: 1.1.3 -> "Bad7zFile: Symlink point out of target directory", /tmp/exp7z NOT created (verify.sh fails); 1.1.0 -> /tmp/exp7z created (verify.sh passes).